### PR TITLE
fix: resolve extension folder path dynamically using import.meta.url

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ const extensionName = 'Presence';
 const extensionFullName = `SillyTavern-${extensionName}`;
 const metadataName = extensionName.toLowerCase().replaceAll('-', '_');
 const htmlSuffix = extensionName.toLowerCase();
-const extensionFolderPath = `scripts/extensions/third-party/${extensionFullName}`;
+const extensionFolderPath = new URL('.', import.meta.url).pathname.replace(/^\//, '').replace(/\/$/, '');
 
 /** @type {ExtensionSettings} */
 const extensionSettings = extension_settings[extensionName];
@@ -128,7 +128,7 @@ const HTML_TEMPLATES = {
                     HTML_TEMPLATES[fileName] = $(response);
                 })
                 .fail(function(jqXHR, textStatus, errorThrown) {
-                    ExtensionName.error({jqXHR, textStatus, errorThrown});
+                    warn('Failed to load HTML template:', textStatus, errorThrown);
                 });
         }
 


### PR DESCRIPTION
The extension folder path was hardcoded as `scripts/extensions/third-party/SillyTavern-Presence`, which breaks when the folder is cloned/named with a `.git` suffix (e.g. `SillyTavern-Presence.git`), causing all HTML template fetches to 404.

Replace the hardcoded path with a dynamic one derived from `import.meta.url` so the correct folder name is always used regardless of how the repo was cloned:

  const extensionFolderPath = new URL('.', import.meta.url).pathname.replace(/^\//, '').replace(/\/$/, '');

Also fix a ReferenceError in the HTML template `.fail()` handler where `ExtensionName.error()` was called but `ExtensionName` is not defined — replaced with the existing `warn()` function.