### PR TITLE
Use fallback path in case extension folder contains .git suffix

### DIFF
--- a/index.js
+++ b/index.js
@@ -407,13 +407,13 @@ function getMessageIdChunks(avatar = null) {
 }
 
 /**
- * Mark a range of messages as hidden ("is_system") or not.
+ * Mark a range of messages as hidden `is_system=true` or not.
  * @param {MessageIdChunk} idChunk An object with "start" and "end" properties indicating the range of message IDs to hide/unhide.
  * @param {boolean} unhide If true, unhide the messages instead.
  * @param {boolean} [saveChat] Whether to save the chat after toggling message visibility.
  * @returns {Promise<void>}
  */
-export async function hideChatMessageRange(idChunk, unhide, saveChat = true) {
+export function hideChatMessageRange(idChunk, unhide, saveChat = true) {
 	let { start, end } = idChunk;
 
 	if (isNaN(start)) return;
@@ -440,7 +440,12 @@ export async function hideChatMessageRange(idChunk, unhide, saveChat = true) {
 	if (saveChat) saveChatDebounced();
 }
 
-export async function toggleVisibilityAllMessages(unhide = false, saveChat = true) {
+/**
+ * @param {boolean} unhide
+ * @param {boolean} saveChat
+ * @returns {void}
+ */
+export function toggleVisibilityAllMessages(unhide = false, saveChat = true) {
 	if (!isActive()) return;
 
 	const messageIdChunks = getMessageIdChunks();
@@ -451,7 +456,12 @@ export async function toggleVisibilityAllMessages(unhide = false, saveChat = tru
 	}
 }
 
-async function updateMessagePresence(mesId, member, isPresent) {
+/**
+ * @param {number|string} mesId
+ * @param {string} member
+ * @param {boolean} isPresent
+ */
+function updateMessagePresence(mesId, member, isPresent) {
 	/** @type {ChatMessageExtended} */
 	const mes = context().chat[mesId];
 	if (!mes.present) mes.present = [];
@@ -466,6 +476,11 @@ async function updateMessagePresence(mesId, member, isPresent) {
 	saveChatDebounced();
 }
 
+/**
+ * @param {string} type Generation type
+ * @param {number|string} charId
+ * @returns {viod}
+ */
 function onGroupMemberDrafted(type, charId) {
 	if (!isActive()) return;
 
@@ -477,7 +492,7 @@ function onGroupMemberDrafted(type, charId) {
 	const avatar = characters[charId].avatar || null;
 
 	if (
-		type == "impersonate" ||
+		type == 'impersonate' ||
 		isUserContinue ||
 		chatMetadata.ignore_presence?.includes(avatar)
 	) {

--- a/index.js
+++ b/index.js
@@ -127,14 +127,31 @@ const HTML_TEMPLATES = {
      * @returns {Promise<JQuery<HTMLElement>>}
      */
     get: async function(fileName = 'settings', {clone = false} = {}) {
+		const extensionFolderPath = HTML_TEMPLATES.extensionFolderPath;
+
 		if (!HTML_TEMPLATES[fileName]) {
-            await $.get(`${extensionFolderPath}/src/html/${fileName}.html`)
-                .done(function(response) {
-                    HTML_TEMPLATES[fileName] = $(response);
-                })
-                .fail(function(jqXHR, textStatus, errorThrown) {
-                    error({jqXHR, textStatus, errorThrown});
-                });
+			try {
+				await $.get(`${extensionFolderPath}/src/html/${fileName}.html`)
+					.done(function(response) {
+						HTML_TEMPLATES[fileName] = $(response);
+					})
+			} catch (err) {
+				const is404 = err?.status === 404;
+
+				error({err});
+
+				if (is404 && !HTML_TEMPLATES.didFallbackFetch) {
+					HTML_TEMPLATES.extensionFolderPath = `${HTML_TEMPLATES.extensionFolderPath}.git`;
+					HTML_TEMPLATES.didFallbackFetch = true;
+
+					error(`Failed to fetch ${fileName}.html, attempting fallback path...`, {err, HTML_TEMPLATES: structuredClone({
+						extensionFolderPath: HTML_TEMPLATES.extensionFolderPath,
+						didFallbackFetch: HTML_TEMPLATES.didFallbackFetch,
+					})});
+
+					return HTML_TEMPLATES.get(fileName, {clone});
+				}
+			}
         }
 
         const $file = HTML_TEMPLATES[fileName];
@@ -145,7 +162,9 @@ const HTML_TEMPLATES = {
         }
 
 		return clone ? $file.clone() : $file;
-    }
+    },
+	didFallbackFetch: false,
+	extensionFolderPath,
 };
 
 function isActive() {

--- a/index.js
+++ b/index.js
@@ -138,7 +138,7 @@ const HTML_TEMPLATES = {
 			} catch (err) {
 				const is404 = err?.status === 404;
 
-				error({err});
+				error('Template rendering error.', {err});
 
 				if (is404 && !HTML_TEMPLATES.didFallbackFetch) {
 					HTML_TEMPLATES.extensionFolderPath = `${HTML_TEMPLATES.extensionFolderPath}.git`;

--- a/index.js
+++ b/index.js
@@ -149,7 +149,7 @@ const HTML_TEMPLATES = {
 						didFallbackFetch: HTML_TEMPLATES.didFallbackFetch,
 					})});
 
-					return HTML_TEMPLATES.get(fileName, {clone});
+					return await HTML_TEMPLATES.get(fileName, {clone});
 				}
 			}
         }

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
     "js": "index.js",
     "css": "style.css",
     "author": "Lackyas, Kaldigo and Leandro",
-    "version": "3.3.1",
+    "version": "3.4.0",
     "minimum_client_version": "1.16.0",
     "homePage": "https://github.com/leandrojofre/SillyTavern-Presence.git",
     "auto_update": true


### PR DESCRIPTION
## Change
GitHub, or some app working as a GH middleman, can append `.git` to the repository folder on clone, breaking extension template loading. If a `404` is detected on template loading error, a fallback path using `.git` suffix will be used for a second try, saving the fallback path for future usage on success.